### PR TITLE
docs: add mac caveat to install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ See the classroom instruction and code comments for more details on each of thes
   * Windows: [Click here for installation instructions](http://gnuwin32.sourceforge.net/packages/make.htm)
 * OpenCV >= 4.1
   * This must be compiled from source using the `-D OPENCV_ENABLE_NONFREE=ON` cmake flag for testing the SIFT and SURF detectors.
+  * If using [homebrew](https://brew.sh/): `$> brew install --build-from-source opencv` will install required dependencies and compile opencv with the `opencv_contrib` module by default (no need to set `-DOPENCV_ENABLE_NONFREE=ON` manually). 
   * The OpenCV 4.1.0 source code can be found [here](https://github.com/opencv/opencv/tree/4.1.0)
 * gcc/g++ >= 5.4
   * Linux: gcc / g++ is installed by default on most Linux distros


### PR DESCRIPTION
the  homebrew build formula for opencv passes the `-DOPENCV_ENABLE_NONFREE=ON` CMake flag and builds from source with the opencv_contrib module by default.
see brew recipe https://github.com/Homebrew/homebrew-core/blob/master/Formula/opencv.rb